### PR TITLE
switching links to simple wikipedia where available

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ var photo = download('http://foo-chan.com/images/sp.jpg')
 uploadPhotoTweet(photo, '@maxogden')
 ```
 
-This synchronous [pseudo-code](http://en.wikipedia.org/wiki/Pseudocode) downloads an adorable cat photo and then uploads the photo to twitter and tweets the photo at `@maxogden`. Pretty straightforward!
+This synchronous [pseudo-code](http://simple.wikipedia.org/wiki/Pseudocode) downloads an adorable cat photo and then uploads the photo to twitter and tweets the photo at `@maxogden`. Pretty straightforward!
 
 (*Author's note: I @maxogden do happily accept random cat photo tweets*)
 


### PR DESCRIPTION
# Rationale
It seemed to me more in keeping with the JS4C philosophy of not scaring beginners/not "teaching CS" to use Simple Wikipedia. If I were a beginner & clicked thru to the English one I would be :fearful: 

## English Wikipedia
> Pseudocode is an informal high-level description of the operating principle of a computer program or other algorithm.
> It uses the structural conventions of a programming language, but is intended for human reading rather than machine reading. Pseudocode typically omits details that are not essential for human understanding of the algorithm, such as variable declarations, system-specific code and some subroutines [.....]
[...5 more paragraphs before examples, which are not simple...]

## Simple English Wikipedia
> Pseudocode (sometimes written as pseudo-code) is a form of source code that is written for humans, not machines, to read. It is often written to show how an algorithm works.
> [Simple examples]

# Notes
I wanted to change out the [Bash article](http://en.wikipedia.org/wiki/Bash_(Unix_shell)) link as well as it's not a good beginner-oriented intro, but _simple._ doesn't have an article for Bash, Terminal, Shell, or Console.  Would another, simpler (non-wikipedia) explanation of Bash be an acceptable substitute?