### PR TITLE
Simplifying replace explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ If you simply type a variable name into the console it will print out the value 
 
 Now that we have our sentence stored in a variable let's give that variable to something that will replace words! We call things that perform actions like this **functions** because, well, they serve a specific *function* (AKA purpose or action) for us. Calling them "actions" sounded weird I guess so they went with the word "function" instead.
 
-JavaScript has a function called `replace` that does exactly what we want! Functions take in any number of values (zero, one or many) and return either nothing (`undefined`) or exactly one value (functions can't return two or more values at a time &mdash; only a single value). The `replace` function is available to use on any strings and takes in two values: the characters to take out and the characters to swap in. It gets confusing to describe these things so here is a visual example:
+JavaScript has a function called `replace` that does exactly what we want! Functions take in any number of values in their parentheses (zero, one or many) and return either nothing (`undefined`) or the changed string. The `replace` function is available to use on any strings and takes in two values: the characters to take out and the characters to swap in. It gets confusing to describe these things so here is a visual example:
 
 ![console](images/console-replace.gif)
 
-Notice how the value of `dogSentence` is the same even after we run `replace` on it? This is because `replace` (and most JavaScript functions for that matter) takes the variable or value that we give it and returns a **new value** instead of modifying the thing we passed in. Since we didn't store the new variable (there is no `=` on the left side of the replace function) it just printed out the return value in our console.
+Notice how the value of `dogSentence` is the same even after we run `replace` on it? This is because the `replace` function, (and most JavaScript functions for that matter) takes the value we give it and returns a **new value**, without modifying the value we passed in. Since we didn't store the result (there is no `=` on the left side of the replace function) it just printed out the return value in our console.
 
 ### <a id="standard-library" href="#standard-library">#</a> The "standard library"
 


### PR DESCRIPTION
Again, my opinions and punch-ups:

I think this is too early to give an aside on even the concept of multiple-return values, a concept not used in Javascript, which is presumably the reader's first language.

Also, I think saying "without modifying the thing we passed in" feels more comforting to the reader than saying "instead of modifying the thing we passed in", which reinforces a feeling of "this isn't what you'd expect" instead of "this is how it is". (Although I know this can be a sticking point for many learners!  I think a solid presentation of the actual behavior could bypass this sticky spot entirely!)

Also replaced a couple instances of `thing` with `value` to prevent the reader from needing to context-switch definitions.

Anyways, your tweet got me re-reading `jsforcats` this morning, by all means, take it or leave it, this is very subjective stuff.